### PR TITLE
fix: remove conflicting @tiptap/html v3 dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
     "@tiptap/extension-image": "^2.4.0",
     "@tiptap/extension-link": "^2.4.0",
     "@tiptap/extension-placeholder": "^2.4.0",
-    "@tiptap/html": "^3.20.3",
     "@tiptap/pm": "^2.4.0",
     "@tiptap/react": "^2.4.0",
     "@tiptap/starter-kit": "^2.4.0",


### PR DESCRIPTION
Removes @tiptap/html@^3.20.3 which caused a peer dependency conflict with all other TipTap v2 packages during Vercel deployment. The package was not imported anywhere in the codebase.