### PR TITLE
feat: rebrand to The Practical Engineer and redesign landing page

### DIFF
--- a/app/(public)/blog/page.tsx
+++ b/app/(public)/blog/page.tsx
@@ -6,8 +6,8 @@ import { PostList } from '@/features/posts/components/PostList'
 export const revalidate = 60
 
 export const metadata: Metadata = {
-  title: 'Blog',
-  description: 'Read our latest articles',
+  title: 'Articles',
+  description: 'Practical knowledge for engineers who ship.',
 }
 
 interface BlogPageProps {
@@ -26,10 +26,10 @@ export default async function BlogPage({ searchParams }: BlogPageProps) {
     <div className="container max-w-5xl mx-auto py-12 px-4 space-y-10">
       {/* Page header */}
       <div className="space-y-2 border-b pb-8">
-        <p className="text-sm font-medium text-primary uppercase tracking-widest">Our Blog</p>
-        <h1 className="text-4xl font-bold tracking-tight">Latest Articles</h1>
+        <p className="text-sm font-medium text-primary uppercase tracking-widest">The Practical Engineer</p>
+        <h1 className="text-4xl font-bold tracking-tight">All Articles</h1>
         <p className="text-muted-foreground text-base max-w-xl">
-          Insights, tutorials, and stories from our team. Stay up to date with the latest.
+          Practical knowledge for engineers who ship. Deep dives, guides, and architecture insights.
         </p>
       </div>
 

--- a/app/(public)/layout.tsx
+++ b/app/(public)/layout.tsx
@@ -10,11 +10,11 @@ export default function PublicLayout({ children }: { children: React.ReactNode }
             className="font-bold text-lg tracking-tight"
             style={{ fontFamily: 'var(--font-playfair, serif)' }}
           >
-            <span style={{ color: '#f59e0b' }}>✦</span> Blog
+            <span style={{ color: '#f59e0b' }}>✦</span> The Practical Engineer
           </Link>
           <nav className="flex items-center gap-6 text-sm">
             <Link href="/blog" className="text-muted-foreground hover:text-foreground transition-colors text-xs uppercase tracking-widest">
-              Blog
+              Articles
             </Link>
             <Link
               href="/dashboard"
@@ -27,7 +27,7 @@ export default function PublicLayout({ children }: { children: React.ReactNode }
       </header>
       <main className="flex-1">{children}</main>
       <footer className="border-t py-8 text-center text-xs text-muted-foreground/60 tracking-wide">
-        <p>&copy; {new Date().getFullYear()} Blog CMS. All rights reserved.</p>
+        <p>&copy; {new Date().getFullYear()} The Practical Engineer. All rights reserved.</p>
       </footer>
     </div>
   )

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -20,10 +20,10 @@ const dmSans = DM_Sans({
 
 export const metadata: Metadata = {
   title: {
-    default: 'Blog CMS',
-    template: '%s | Blog CMS',
+    default: 'The Practical Engineer',
+    template: '%s | The Practical Engineer',
   },
-  description: 'A modern blog CMS built with Next.js and Supabase',
+  description: 'Practical knowledge for engineers who ship. Deep dives, guides, and architecture insights.',
 }
 
 export default function RootLayout({

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,575 +1,701 @@
 import Link from 'next/link'
 
-const features = [
+const pillars = [
   {
-    icon: '✦',
-    title: 'WYSIWYG Editor',
-    desc: 'Rich text editing powered by TipTap — full formatting, media embeds, and real-time preview built in.',
+    num: '01',
+    title: 'System Design',
+    desc: 'Architecture decisions, trade-offs, and the thinking behind systems that scale and survive production.',
   },
   {
-    icon: '◈',
-    title: 'Role-Based Access',
-    desc: 'Admin and Author roles with Supabase RLS enforcing security at the database level. Zero-trust by default.',
+    num: '02',
+    title: 'Engineering Craft',
+    desc: 'Clean code, testing, debugging strategies, and the fundamentals that separate good engineers from great ones.',
   },
   {
-    icon: '◎',
-    title: 'Draft & Publish',
-    desc: 'Full editorial workflow with draft, review, and publish states so your team can collaborate flawlessly.',
+    num: '03',
+    title: 'Performance',
+    desc: 'Making software faster. Profiling, optimization, and measuring what actually matters at scale.',
   },
   {
-    icon: '⬡',
-    title: 'App Router Native',
-    desc: 'Built on Next.js 15 App Router with server components, streaming, and edge-ready architecture.',
+    num: '04',
+    title: 'Tooling & DX',
+    desc: 'The tools, configurations, and workflows that compound over time and make engineers dramatically more productive.',
   },
   {
-    icon: '◇',
-    title: 'Supabase Backend',
-    desc: 'Postgres database with real-time capabilities, auth, and storage — all managed through Supabase.',
+    num: '05',
+    title: 'Career & Growth',
+    desc: 'Getting better at the craft over time. Technical leadership, communication, and leveling up deliberately.',
   },
   {
-    icon: '❋',
-    title: 'Fully Open',
-    desc: 'Customizable and extensible. Own your data, your code, your content — no lock-in, ever.',
+    num: '06',
+    title: 'Open Source',
+    desc: 'Building, contributing, and maintaining software in the open. What it takes and why it matters.',
   },
 ]
 
-const stack = [
-  { label: 'Framework', value: 'Next.js 15' },
-  { label: 'Database', value: 'Supabase' },
-  { label: 'Styling', value: 'Tailwind CSS' },
-  { label: 'Editor', value: 'TipTap' },
+const stats = [
+  { value: 'Deep Dives', label: 'Long-form technical' },
+  { value: 'Guides', label: 'Step-by-step practical' },
+  { value: 'Architecture', label: 'System design decisions' },
+  { value: 'No fluff', label: 'Direct and honest' },
 ]
 
 export default function Home() {
   return (
-    <div className="landing-root">
-      {/* Ambient glow */}
-      <div className="ambient-glow" aria-hidden />
+    <div className="tpe-root">
+      {/* Graph-paper texture overlay */}
+      <div className="tpe-texture" aria-hidden />
+      {/* Amber glow */}
+      <div className="tpe-glow" aria-hidden />
 
-      {/* ── Navigation ── */}
-      <nav className="landing-nav">
-        <div className="nav-inner">
-          <span className="nav-logo">
-            <span className="accent">✦</span> Blog
-          </span>
-          <div className="nav-links">
-            <Link href="/blog" className="nav-link-ghost">Blog</Link>
-            <Link href="/dashboard" className="nav-link-solid">Dashboard →</Link>
+      {/* ── Nav ── */}
+      <nav className="tpe-nav">
+        <div className="tpe-nav-inner">
+          <Link href="/" className="tpe-logo">
+            <span className="tpe-logo-accent">✦</span>
+            <span className="tpe-logo-text">The Practical Engineer</span>
+          </Link>
+          <div className="tpe-nav-links">
+            <Link href="/blog" className="tpe-nav-ghost">Articles</Link>
+            <Link href="/dashboard" className="tpe-nav-solid">Dashboard →</Link>
           </div>
         </div>
       </nav>
 
       {/* ── Hero ── */}
-      <section className="hero-section">
-        <div className="hero-inner">
-          <div className="hero-badge">
-            <span className="badge-dot" aria-hidden />
-            <span>Modern Publishing Platform</span>
+      <section className="tpe-hero">
+        {/* Vertical rule + issue label */}
+        <div className="tpe-issue-label" aria-hidden>
+          <span className="tpe-issue-rule" />
+          <span className="tpe-issue-text">Engineering Knowledge</span>
+        </div>
+
+        <div className="tpe-hero-content">
+          <div className="tpe-hero-badge">
+            <span className="tpe-badge-pip" aria-hidden />
+            <span>Practical · Honest · Opinionated</span>
           </div>
 
-          <h1 className="hero-headline">
-            <span className="headline-line">Write.</span>
-            <span className="headline-line headline-shimmer">Publish.</span>
-            <span className="headline-line">Inspire.</span>
+          <h1 className="tpe-hero-title">
+            <span className="tpe-title-the">The</span>
+            <span className="tpe-title-practical">Practical</span>
+            <span className="tpe-title-engineer">Engineer<span className="tpe-title-dot">.</span></span>
           </h1>
 
-          <p className="hero-body">
-            A full-stack Blog CMS built for modern teams. Draft, edit, and publish
-            with a powerful WYSIWYG editor, role-based access control, and a
-            Supabase-powered backend.
+          <p className="tpe-hero-sub">
+            In-depth technical writing for engineers who care about craft.
+            No padding, no filler — just hard-won knowledge from real engineering work.
           </p>
 
-          <div className="hero-actions">
-            <Link href="/blog" className="btn-primary">
-              Read the Blog <span aria-hidden>→</span>
+          <div className="tpe-hero-actions">
+            <Link href="/blog" className="tpe-btn-primary">
+              Read Articles <span aria-hidden>→</span>
             </Link>
-            <Link href="/dashboard" className="btn-outline">
+            <Link href="/dashboard" className="tpe-btn-ghost">
               Open Dashboard
             </Link>
           </div>
         </div>
 
-        {/* Decorative oversized quote */}
-        <div className="deco-quote" aria-hidden>&ldquo;</div>
+        {/* Decorative large number */}
+        <div className="tpe-deco-num" aria-hidden>01</div>
       </section>
 
-      {/* ── Stack bar ── */}
-      <section className="stack-bar">
-        <div className="stack-inner">
-          {stack.map((item, i) => (
-            <div key={i} className={`stack-item${i < stack.length - 1 ? ' stack-item--border' : ''}`}>
-              <div className="stack-label">{item.label}</div>
-              <div className="stack-value">{item.value}</div>
+      {/* ── Pillars strip ── */}
+      <div className="tpe-strip">
+        <div className="tpe-strip-inner">
+          {stats.map((s, i) => (
+            <div key={i} className={`tpe-strip-item${i < stats.length - 1 ? ' tpe-strip-item--sep' : ''}`}>
+              <div className="tpe-strip-value">{s.value}</div>
+              <div className="tpe-strip-label">{s.label}</div>
             </div>
           ))}
         </div>
-      </section>
+      </div>
 
-      {/* ── Features ── */}
-      <section className="features-section">
-        <div className="features-inner">
-          <div className="section-eyebrow">Features</div>
-          <h2 className="section-headline">
-            Everything you need<br className="br-desktop" /> to publish brilliantly.
+      {/* ── Topics ── */}
+      <section className="tpe-topics">
+        <div className="tpe-topics-header">
+          <div className="tpe-section-eye">What you&apos;ll find</div>
+          <h2 className="tpe-section-title">
+            Six pillars of<br className="tpe-br-md" /> practical engineering.
           </h2>
         </div>
 
-        <div className="features-grid">
-          {features.map((feature, i) => (
-            <div key={i} className="feature-card">
-              <div className="feature-icon" aria-hidden>{feature.icon}</div>
-              <h3 className="feature-title">{feature.title}</h3>
-              <p className="feature-desc">{feature.desc}</p>
+        <div className="tpe-topics-grid">
+          {pillars.map((p) => (
+            <div key={p.num} className="tpe-topic-card">
+              <span className="tpe-topic-num">{p.num}</span>
+              <h3 className="tpe-topic-title">{p.title}</h3>
+              <p className="tpe-topic-desc">{p.desc}</p>
             </div>
           ))}
         </div>
       </section>
 
-      {/* ── CTA Banner ── */}
-      <section className="cta-section">
-        <div className="cta-pattern" aria-hidden />
-        <h2 className="cta-headline">Start writing today.</h2>
-        <p className="cta-body">
-          Jump into the dashboard and begin crafting your first post in minutes.
-        </p>
-        <Link href="/dashboard" className="btn-dark">
-          Open Dashboard →
-        </Link>
+      {/* ── Pull quote ── */}
+      <section className="tpe-quote-section">
+        <div className="tpe-quote-rule" aria-hidden />
+        <blockquote className="tpe-quote">
+          &ldquo;The goal is not to write about engineering.
+          <br className="tpe-br-md" /> The goal is to make you a better engineer.&rdquo;
+        </blockquote>
+        <div className="tpe-quote-rule" aria-hidden />
+      </section>
+
+      {/* ── CTA ── */}
+      <section className="tpe-cta">
+        <div className="tpe-cta-hatch" aria-hidden />
+        <div className="tpe-cta-inner">
+          <div className="tpe-section-eye tpe-eye-dark">Start reading</div>
+          <h2 className="tpe-cta-title">Engineering insights,<br /> delivered with intent.</h2>
+          <p className="tpe-cta-body">
+            Every article is written to give you something you can use.
+            No fluff, no filler — just knowledge that compounds.
+          </p>
+          <Link href="/blog" className="tpe-btn-dark">
+            Browse All Articles →
+          </Link>
+        </div>
       </section>
 
       {/* ── Footer ── */}
-      <footer className="landing-footer">
-        <div className="footer-inner">
-          <span className="nav-logo footer-logo">
-            <span className="accent">✦</span> Blog
+      <footer className="tpe-footer">
+        <div className="tpe-footer-inner">
+          <span className="tpe-footer-logo">
+            <span className="tpe-logo-accent">✦</span> The Practical Engineer
           </span>
-          <p className="footer-copy">© {new Date().getFullYear()} Blog CMS. Built with Next.js &amp; Supabase.</p>
-          <div className="footer-links">
-            <Link href="/blog" className="footer-link">Blog</Link>
-            <Link href="/dashboard" className="footer-link">Dashboard</Link>
+          <p className="tpe-footer-copy">
+            © {new Date().getFullYear()} The Practical Engineer. Built with Next.js &amp; Supabase.
+          </p>
+          <div className="tpe-footer-links">
+            <Link href="/blog" className="tpe-footer-link">Articles</Link>
+            <Link href="/dashboard" className="tpe-footer-link">Dashboard</Link>
           </div>
         </div>
       </footer>
 
       <style>{`
-        /* ── Reset & root ── */
-        .landing-root {
-          background-color: #080808;
-          color: #f0ece4;
+        /* ── Root ── */
+        .tpe-root {
+          background-color: #070707;
+          color: #ede8df;
           font-family: var(--font-dm-sans, sans-serif);
           min-height: 100vh;
           position: relative;
           overflow-x: hidden;
         }
 
-        /* ── Ambient glow ── */
-        .ambient-glow {
+        /* ── Graph-paper texture ── */
+        .tpe-texture {
           position: fixed;
-          top: -15%;
-          left: 25%;
-          width: min(700px, 100vw);
-          height: min(700px, 100vw);
-          background: radial-gradient(circle, rgba(245,158,11,0.07) 0%, transparent 65%);
+          inset: 0;
+          background-image:
+            linear-gradient(rgba(245,158,11,0.025) 1px, transparent 1px),
+            linear-gradient(90deg, rgba(245,158,11,0.025) 1px, transparent 1px);
+          background-size: 40px 40px;
           pointer-events: none;
           z-index: 0;
         }
 
-        /* ── Accent ── */
-        .accent { color: #f59e0b; }
+        /* ── Amber glow ── */
+        .tpe-glow {
+          position: fixed;
+          top: -10%;
+          right: -5%;
+          width: min(800px, 120vw);
+          height: min(800px, 120vw);
+          background: radial-gradient(circle at 70% 30%, rgba(245,158,11,0.06) 0%, transparent 60%);
+          pointer-events: none;
+          z-index: 0;
+        }
 
         /* ── Nav ── */
-        .landing-nav {
+        .tpe-nav {
           position: relative;
           z-index: 10;
         }
-        .nav-inner {
-          max-width: 1200px;
+        .tpe-nav-inner {
+          max-width: 1280px;
           margin: 0 auto;
-          padding: 24px 32px;
+          padding: 28px 48px;
           display: flex;
           align-items: center;
           justify-content: space-between;
         }
-        .nav-logo {
-          font-family: var(--font-playfair, serif);
-          font-size: 20px;
-          font-weight: 700;
-          letter-spacing: -0.02em;
-          color: #f0ece4;
-        }
-        .nav-links {
+        .tpe-logo {
           display: flex;
           align-items: center;
-          gap: 28px;
+          gap: 10px;
+          text-decoration: none;
         }
-        .nav-link-ghost {
-          font-size: 12px;
-          letter-spacing: 0.1em;
+        .tpe-logo-accent { color: #f59e0b; font-size: 16px; }
+        .tpe-logo-text {
+          font-family: var(--font-playfair, serif);
+          font-size: 18px;
+          font-weight: 700;
+          letter-spacing: -0.02em;
+          color: #ede8df;
+        }
+        .tpe-nav-links {
+          display: flex;
+          align-items: center;
+          gap: 32px;
+        }
+        .tpe-nav-ghost {
+          font-size: 11px;
+          letter-spacing: 0.14em;
           text-transform: uppercase;
-          color: #6b6560;
+          color: #5a5550;
           text-decoration: none;
           transition: color 0.2s;
         }
-        .nav-link-ghost:hover { color: #f0ece4; }
-        .nav-link-solid {
-          font-size: 12px;
-          letter-spacing: 0.08em;
+        .tpe-nav-ghost:hover { color: #ede8df; }
+        .tpe-nav-solid {
+          font-size: 11px;
+          letter-spacing: 0.1em;
           text-transform: uppercase;
-          color: #080808;
-          background-color: #f0ece4;
-          padding: 10px 22px;
-          text-decoration: none;
           font-weight: 700;
+          color: #070707;
+          background-color: #ede8df;
+          padding: 10px 24px;
+          text-decoration: none;
           transition: background-color 0.2s;
         }
-        .nav-link-solid:hover { background-color: #f59e0b; }
+        .tpe-nav-solid:hover { background-color: #f59e0b; }
 
         /* ── Hero ── */
-        .hero-section {
+        .tpe-hero {
           position: relative;
           z-index: 2;
-          max-width: 1200px;
+          max-width: 1280px;
           margin: 0 auto;
-          padding: 80px 32px 120px;
+          padding: 80px 48px 120px;
+          display: flex;
+          align-items: flex-start;
+          gap: 48px;
         }
-        .hero-inner { max-width: 700px; }
 
-        .hero-badge {
-          display: inline-flex;
+        /* Vertical rule + rotated label */
+        .tpe-issue-label {
+          display: flex;
+          flex-direction: column;
           align-items: center;
-          gap: 8px;
-          margin-bottom: 40px;
-          padding: 6px 14px;
-          border: 1px solid rgba(245,158,11,0.35);
-        }
-        .badge-dot {
-          width: 6px;
-          height: 6px;
-          background-color: #f59e0b;
-          border-radius: 50%;
-          display: block;
+          gap: 16px;
+          padding-top: 8px;
           flex-shrink: 0;
         }
-        .hero-badge span:last-child {
+        .tpe-issue-rule {
+          display: block;
+          width: 1px;
+          height: 80px;
+          background: linear-gradient(to bottom, transparent, rgba(245,158,11,0.5));
+        }
+        .tpe-issue-text {
+          font-size: 10px;
+          letter-spacing: 0.2em;
+          text-transform: uppercase;
+          color: #3a3530;
+          writing-mode: vertical-rl;
+          text-orientation: mixed;
+        }
+
+        .tpe-hero-content { flex: 1; max-width: 780px; }
+
+        .tpe-hero-badge {
+          display: inline-flex;
+          align-items: center;
+          gap: 10px;
+          margin-bottom: 44px;
+          padding: 7px 16px;
+          border: 1px solid rgba(245,158,11,0.3);
+        }
+        .tpe-badge-pip {
+          width: 6px; height: 6px;
+          background-color: #f59e0b;
+          border-radius: 50%;
+          flex-shrink: 0;
+        }
+        .tpe-hero-badge span:last-child {
           font-size: 11px;
-          letter-spacing: 0.15em;
+          letter-spacing: 0.16em;
           text-transform: uppercase;
           color: #f59e0b;
         }
 
-        .hero-headline {
-          font-family: var(--font-playfair, serif);
-          font-size: clamp(52px, 9vw, 112px);
-          font-weight: 700;
-          line-height: 1.0;
+        /* Title stack */
+        .tpe-hero-title {
+          margin: 0 0 36px;
+          line-height: 0.92;
           letter-spacing: -0.04em;
-          margin: 0 0 32px;
-          color: #f0ece4;
         }
-        .headline-line { display: block; }
-        .headline-shimmer {
-          background-image: linear-gradient(90deg, #f59e0b 0%, #fde68a 40%, #f59e0b 80%);
+        .tpe-title-the {
+          display: block;
+          font-family: var(--font-playfair, serif);
+          font-style: italic;
+          font-size: clamp(28px, 4.5vw, 56px);
+          font-weight: 400;
+          color: #5a5550;
+        }
+        .tpe-title-practical {
+          display: block;
+          font-family: var(--font-playfair, serif);
+          font-size: clamp(68px, 11vw, 140px);
+          font-weight: 700;
+          color: #ede8df;
+        }
+        .tpe-title-engineer {
+          display: block;
+          font-family: var(--font-playfair, serif);
+          font-size: clamp(68px, 11vw, 140px);
+          font-weight: 700;
+          background-image: linear-gradient(90deg, #f59e0b 0%, #fde68a 45%, #f59e0b 90%);
           background-size: 200% auto;
           -webkit-background-clip: text;
           -webkit-text-fill-color: transparent;
           background-clip: text;
-          animation: shimmer 4s linear infinite;
+          animation: tpe-shimmer 5s linear infinite;
+        }
+        .tpe-title-dot {
+          color: #f59e0b;
+          -webkit-text-fill-color: #f59e0b;
         }
 
-        .hero-body {
-          font-size: 18px;
+        .tpe-hero-sub {
+          font-size: 19px;
           line-height: 1.75;
-          color: #6b6560;
-          margin: 0 0 40px;
-          max-width: 540px;
+          color: #5a5550;
+          max-width: 560px;
+          margin: 0 0 44px;
         }
 
-        .hero-actions {
+        .tpe-hero-actions {
           display: flex;
           gap: 14px;
           flex-wrap: wrap;
         }
-
-        .btn-primary {
-          padding: 14px 32px;
+        .tpe-btn-primary {
+          padding: 15px 36px;
           background-color: #f59e0b;
-          color: #080808;
+          color: #070707;
           text-decoration: none;
           font-weight: 700;
-          font-size: 14px;
-          letter-spacing: 0.04em;
+          font-size: 13px;
+          letter-spacing: 0.06em;
+          text-transform: uppercase;
           display: inline-flex;
           align-items: center;
           gap: 8px;
           transition: background-color 0.2s, transform 0.15s;
         }
-        .btn-primary:hover {
+        .tpe-btn-primary:hover {
           background-color: #fbbf24;
-          transform: translateY(-1px);
+          transform: translateY(-2px);
         }
-
-        .btn-outline {
-          padding: 14px 32px;
-          border: 1px solid rgba(240,236,228,0.2);
-          color: #f0ece4;
+        .tpe-btn-ghost {
+          padding: 15px 36px;
+          border: 1px solid rgba(237,232,223,0.15);
+          color: #ede8df;
           text-decoration: none;
           font-weight: 500;
-          font-size: 14px;
-          letter-spacing: 0.04em;
+          font-size: 13px;
+          letter-spacing: 0.06em;
           display: inline-flex;
           align-items: center;
           gap: 8px;
           transition: border-color 0.2s, color 0.2s;
         }
-        .btn-outline:hover {
-          border-color: rgba(240,236,228,0.5);
+        .tpe-btn-ghost:hover {
+          border-color: rgba(237,232,223,0.4);
           color: #fff;
         }
 
-        .deco-quote {
+        /* Decorative oversized number */
+        .tpe-deco-num {
           position: absolute;
-          top: 20px;
-          right: 40px;
+          bottom: 40px;
+          right: 48px;
           font-family: var(--font-playfair, serif);
-          font-size: clamp(200px, 28vw, 420px);
-          color: rgba(245,158,11,0.035);
-          line-height: 1;
-          user-select: none;
-          pointer-events: none;
+          font-size: clamp(120px, 18vw, 260px);
           font-weight: 700;
+          color: rgba(245,158,11,0.04);
+          line-height: 1;
+          pointer-events: none;
+          user-select: none;
+          letter-spacing: -0.06em;
         }
 
-        /* ── Stack bar ── */
-        .stack-bar {
+        /* ── Strip ── */
+        .tpe-strip {
           position: relative;
           z-index: 2;
-          border-top: 1px solid rgba(240,236,228,0.07);
-          border-bottom: 1px solid rgba(240,236,228,0.07);
+          border-top: 1px solid rgba(237,232,223,0.07);
+          border-bottom: 1px solid rgba(237,232,223,0.07);
         }
-        .stack-inner {
-          max-width: 1200px;
+        .tpe-strip-inner {
+          max-width: 1280px;
           margin: 0 auto;
           display: grid;
           grid-template-columns: repeat(4, 1fr);
         }
-        .stack-item {
-          padding: 28px 32px;
+        .tpe-strip-item {
+          padding: 28px 48px;
         }
-        .stack-item--border {
-          border-right: 1px solid rgba(240,236,228,0.07);
+        .tpe-strip-item--sep {
+          border-right: 1px solid rgba(237,232,223,0.07);
         }
-        .stack-label {
-          font-size: 11px;
-          letter-spacing: 0.12em;
-          text-transform: uppercase;
-          color: #4a4540;
-          margin-bottom: 8px;
-        }
-        .stack-value {
+        .tpe-strip-value {
           font-family: var(--font-playfair, serif);
           font-size: 20px;
           font-weight: 600;
-          color: #f0ece4;
+          color: #ede8df;
+          margin-bottom: 6px;
+          letter-spacing: -0.01em;
+        }
+        .tpe-strip-label {
+          font-size: 11px;
+          letter-spacing: 0.1em;
+          text-transform: uppercase;
+          color: #3a3530;
         }
 
-        /* ── Features ── */
-        .features-section {
+        /* ── Topics ── */
+        .tpe-topics {
           position: relative;
           z-index: 2;
-          max-width: 1200px;
+          max-width: 1280px;
           margin: 0 auto;
-          padding: 100px 32px;
+          padding: 108px 48px;
         }
-        .features-inner {
-          margin-bottom: 56px;
-        }
-        .section-eyebrow {
+        .tpe-topics-header { margin-bottom: 64px; }
+        .tpe-section-eye {
           font-size: 11px;
-          letter-spacing: 0.18em;
+          letter-spacing: 0.2em;
           text-transform: uppercase;
           color: #f59e0b;
-          margin-bottom: 16px;
+          margin-bottom: 18px;
         }
-        .section-headline {
+        .tpe-section-title {
           font-family: var(--font-playfair, serif);
-          font-size: clamp(30px, 4.5vw, 52px);
+          font-size: clamp(32px, 5vw, 56px);
           font-weight: 700;
           letter-spacing: -0.03em;
-          color: #f0ece4;
+          color: #ede8df;
           margin: 0;
           line-height: 1.1;
         }
-        .br-desktop { display: block; }
 
-        .features-grid {
+        .tpe-topics-grid {
           display: grid;
           grid-template-columns: repeat(3, 1fr);
           gap: 1px;
-          background-color: rgba(240,236,228,0.06);
-          border: 1px solid rgba(240,236,228,0.06);
+          background-color: rgba(237,232,223,0.06);
+          border: 1px solid rgba(237,232,223,0.06);
         }
-        .feature-card {
-          padding: 40px;
-          background-color: #080808;
-          transition: background-color 0.3s;
+        .tpe-topic-card {
+          padding: 44px;
+          background-color: #070707;
+          transition: background-color 0.25s;
+          position: relative;
         }
-        .feature-card:hover { background-color: #0e0d0c; }
-        .feature-icon {
-          font-size: 22px;
+        .tpe-topic-card:hover { background-color: #0f0e0c; }
+        .tpe-topic-num {
+          display: block;
+          font-family: var(--font-playfair, serif);
+          font-size: 11px;
+          letter-spacing: 0.14em;
           color: #f59e0b;
           margin-bottom: 20px;
-          font-family: monospace;
         }
-        .feature-title {
+        .tpe-topic-title {
           font-family: var(--font-playfair, serif);
-          font-size: 19px;
+          font-size: 21px;
           font-weight: 600;
-          color: #f0ece4;
-          margin: 0 0 12px;
-          letter-spacing: -0.01em;
+          color: #ede8df;
+          margin: 0 0 14px;
+          letter-spacing: -0.02em;
         }
-        .feature-desc {
+        .tpe-topic-desc {
           font-size: 14px;
-          line-height: 1.75;
-          color: #4a4540;
+          line-height: 1.8;
+          color: #3a3530;
           margin: 0;
         }
 
-        /* ── CTA ── */
-        .cta-section {
+        /* ── Pull quote ── */
+        .tpe-quote-section {
           position: relative;
           z-index: 2;
-          background-color: #f0ece4;
-          margin: 0 32px 80px;
-          padding: 72px 48px;
+          max-width: 1280px;
+          margin: 0 auto;
+          padding: 0 48px 100px;
           display: flex;
           flex-direction: column;
           align-items: center;
+          gap: 32px;
           text-align: center;
+        }
+        .tpe-quote-rule {
+          width: 60px;
+          height: 1px;
+          background-color: rgba(245,158,11,0.35);
+        }
+        .tpe-quote {
+          font-family: var(--font-playfair, serif);
+          font-style: italic;
+          font-size: clamp(20px, 3vw, 30px);
+          line-height: 1.5;
+          color: #5a5550;
+          margin: 0;
+          max-width: 700px;
+          letter-spacing: -0.01em;
+        }
+
+        /* ── CTA ── */
+        .tpe-cta {
+          position: relative;
+          z-index: 2;
+          background-color: #ede8df;
+          margin: 0 48px 80px;
           overflow: hidden;
         }
-        .cta-pattern {
+        .tpe-cta-hatch {
           position: absolute;
           inset: 0;
           background-image: repeating-linear-gradient(
-            45deg,
-            rgba(8,8,8,0.03) 0px,
-            rgba(8,8,8,0.03) 1px,
+            -45deg,
+            rgba(7,7,7,0.025) 0px,
+            rgba(7,7,7,0.025) 1px,
             transparent 1px,
-            transparent 22px
+            transparent 20px
           );
           pointer-events: none;
         }
-        .cta-headline {
+        .tpe-cta-inner {
+          position: relative;
+          z-index: 1;
+          padding: 80px 64px;
+          display: flex;
+          flex-direction: column;
+          align-items: flex-start;
+          max-width: 640px;
+        }
+        .tpe-eye-dark {
+          color: #a09880;
+        }
+        .tpe-cta-title {
           font-family: var(--font-playfair, serif);
-          font-size: clamp(28px, 5vw, 52px);
+          font-size: clamp(30px, 5vw, 54px);
           font-weight: 700;
-          color: #080808;
+          color: #070707;
           letter-spacing: -0.03em;
           line-height: 1.1;
-          margin: 0 0 20px;
-          position: relative;
-          z-index: 1;
+          margin: 0 0 22px;
         }
-        .cta-body {
+        .tpe-cta-body {
           font-size: 16px;
           color: #6b6560;
-          margin: 0 0 40px;
-          max-width: 420px;
-          line-height: 1.65;
-          position: relative;
-          z-index: 1;
+          line-height: 1.7;
+          margin: 0 0 44px;
+          max-width: 460px;
         }
-        .btn-dark {
-          position: relative;
-          z-index: 1;
+        .tpe-btn-dark {
           padding: 16px 40px;
-          background-color: #080808;
-          color: #f0ece4;
+          background-color: #070707;
+          color: #ede8df;
           text-decoration: none;
           font-weight: 700;
-          font-size: 13px;
-          letter-spacing: 0.1em;
+          font-size: 12px;
+          letter-spacing: 0.12em;
           text-transform: uppercase;
           display: inline-flex;
           align-items: center;
           gap: 8px;
           transition: background-color 0.2s, transform 0.15s;
         }
-        .btn-dark:hover {
-          background-color: #1a1a1a;
-          transform: translateY(-1px);
+        .tpe-btn-dark:hover {
+          background-color: #1a1a18;
+          transform: translateY(-2px);
         }
 
         /* ── Footer ── */
-        .landing-footer {
+        .tpe-footer {
           position: relative;
           z-index: 2;
-          border-top: 1px solid rgba(240,236,228,0.06);
+          border-top: 1px solid rgba(237,232,223,0.06);
         }
-        .footer-inner {
-          max-width: 1200px;
+        .tpe-footer-inner {
+          max-width: 1280px;
           margin: 0 auto;
-          padding: 32px;
+          padding: 32px 48px;
           display: flex;
           align-items: center;
           justify-content: space-between;
           gap: 16px;
         }
-        .footer-logo { color: #4a4540; font-size: 15px; }
-        .footer-copy { font-size: 12px; color: #2e2c2a; margin: 0; }
-        .footer-links { display: flex; gap: 24px; }
-        .footer-link {
+        .tpe-footer-logo {
+          font-family: var(--font-playfair, serif);
+          font-size: 15px;
+          font-weight: 600;
+          color: #3a3530;
+          letter-spacing: -0.01em;
+        }
+        .tpe-footer-copy { font-size: 12px; color: #2a2825; margin: 0; }
+        .tpe-footer-links { display: flex; gap: 24px; }
+        .tpe-footer-link {
           font-size: 12px;
-          color: #4a4540;
+          color: #3a3530;
           text-decoration: none;
           transition: color 0.2s;
         }
-        .footer-link:hover { color: #f0ece4; }
+        .tpe-footer-link:hover { color: #ede8df; }
 
         /* ── Animations ── */
-        @keyframes shimmer {
-          0%   { background-position: 0%   center; }
+        @keyframes tpe-shimmer {
+          0%   { background-position: 0% center; }
           100% { background-position: 200% center; }
         }
 
-        /* ── Tablet (≤ 900px) ── */
-        @media (max-width: 900px) {
-          .nav-inner { padding: 20px 24px; }
-          .hero-section { padding: 60px 24px 90px; }
-          .deco-quote { display: none; }
-          .features-section { padding: 72px 24px; }
-          .features-grid { grid-template-columns: repeat(2, 1fr); }
-          .stack-inner { grid-template-columns: repeat(2, 1fr); }
-          .stack-item--border:nth-child(2) { border-right: none; }
-          .stack-item:nth-child(1),
-          .stack-item:nth-child(2) {
-            border-bottom: 1px solid rgba(240,236,228,0.07);
-          }
-          .cta-section { margin: 0 24px 64px; padding: 56px 32px; }
-          .footer-inner { flex-direction: column; text-align: center; gap: 12px; }
-          .br-desktop { display: none; }
+        /* ── Tablet ── */
+        @media (max-width: 960px) {
+          .tpe-nav-inner { padding: 22px 28px; }
+          .tpe-logo-text { font-size: 15px; }
+          .tpe-hero { padding: 60px 28px 90px; flex-direction: column; gap: 0; }
+          .tpe-issue-label { display: none; }
+          .tpe-deco-num { display: none; }
+          .tpe-strip-inner { grid-template-columns: repeat(2, 1fr); }
+          .tpe-strip-item--sep:nth-child(2) { border-right: none; }
+          .tpe-strip-item:nth-child(1),
+          .tpe-strip-item:nth-child(2) { border-bottom: 1px solid rgba(237,232,223,0.07); }
+          .tpe-strip-item { padding: 24px 28px; }
+          .tpe-topics { padding: 80px 28px; }
+          .tpe-topics-grid { grid-template-columns: repeat(2, 1fr); }
+          .tpe-quote-section { padding: 0 28px 80px; }
+          .tpe-cta { margin: 0 28px 64px; }
+          .tpe-cta-inner { padding: 60px 40px; }
+          .tpe-footer-inner { flex-direction: column; text-align: center; gap: 12px; }
+          .tpe-footer-inner { padding: 28px; }
+          .tpe-br-md { display: none; }
         }
 
-        /* ── Mobile (≤ 600px) ── */
+        /* ── Mobile ── */
         @media (max-width: 600px) {
-          .nav-inner { padding: 18px 20px; }
-          .nav-link-ghost { display: none; }
-          .hero-section { padding: 48px 20px 72px; }
-          .hero-body { font-size: 16px; }
-          .hero-actions { flex-direction: column; }
-          .btn-primary, .btn-outline { width: 100%; justify-content: center; }
-          .features-grid { grid-template-columns: 1fr; }
-          .features-section { padding: 56px 20px; }
-          .stack-inner {
-            grid-template-columns: 1fr 1fr;
-            padding: 0 0;
-          }
-          .stack-item { padding: 20px 20px; }
-          .cta-section { margin: 0 20px 56px; padding: 48px 24px; }
-          .footer-inner { padding: 24px 20px; }
-          .footer-links { gap: 16px; }
-          .hero-badge { margin-bottom: 28px; }
+          .tpe-nav-inner { padding: 18px 20px; }
+          .tpe-nav-ghost { display: none; }
+          .tpe-logo-text { font-size: 13px; }
+          .tpe-hero { padding: 40px 20px 64px; }
+          .tpe-hero-badge { margin-bottom: 32px; }
+          .tpe-hero-sub { font-size: 16px; }
+          .tpe-hero-actions { flex-direction: column; }
+          .tpe-btn-primary, .tpe-btn-ghost { width: 100%; justify-content: center; }
+          .tpe-topics { padding: 64px 20px; }
+          .tpe-topics-grid { grid-template-columns: 1fr; }
+          .tpe-topic-card { padding: 32px 28px; }
+          .tpe-quote-section { padding: 0 20px 64px; }
+          .tpe-cta { margin: 0 20px 56px; }
+          .tpe-cta-inner { padding: 48px 28px; }
+          .tpe-footer-inner { padding: 24px 20px; }
+          .tpe-footer-links { gap: 16px; }
         }
       `}</style>
     </div>


### PR DESCRIPTION
- Rename site from "Blog" to "The Practical Engineer" across all pages, metadata, nav, and footer
- Full landing page redesign with editorial magazine aesthetic:
  - Stacked typographic hero title (The / Practical / Engineer)
  - Graph-paper texture overlay nodding to engineering blueprints
  - Vertical rule + rotated label side detail in hero
  - Content pillars section replacing generic CMS features
  - Editorial pull-quote section
  - Left-aligned CTA with hatch pattern background
- Update /blog listing page copy and metadata to match new brand
Closes #17 