### PR TITLE
feat: redesign developer page with tabs and fix auth/signout

### DIFF
--- a/app/(dashboard)/dashboard/developer/ApiKeysManager.tsx
+++ b/app/(dashboard)/dashboard/developer/ApiKeysManager.tsx
@@ -8,7 +8,6 @@ import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { Badge } from '@/components/ui/badge'
 import { Card } from '@/components/ui/card'
-import { ApiReferenceSection } from '@/components/developer/ApiReferenceSection'
 import {
   Dialog,
   DialogContent,
@@ -198,8 +197,6 @@ export function ApiKeysManager({ initialKeys }: ApiKeysManagerProps) {
           </div>
         )}
       </Card>
-
-      <ApiReferenceSection />
 
       {/* Generate Key Dialog */}
       <Dialog open={dialogOpen} onOpenChange={(open) => { if (!open) handleDialogClose() }}>

--- a/app/(dashboard)/dashboard/developer/page.tsx
+++ b/app/(dashboard)/dashboard/developer/page.tsx
@@ -2,7 +2,9 @@ import type { Metadata } from 'next'
 import { listApiKeys } from '@/features/api-keys/apiKeyService'
 import { ApiKeysManager } from './ApiKeysManager'
 import { LLMProvidersManager } from '@/components/ai-assistant/LLMProvidersManager'
+import { ApiReferenceSection } from '@/components/developer/ApiReferenceSection'
 import { requirePermission } from '@/lib/auth/session'
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 
 export const metadata: Metadata = { title: 'Developer Settings' }
 
@@ -19,8 +21,26 @@ export default async function DeveloperPage() {
           Manage API keys for external integrations
         </p>
       </div>
-      <ApiKeysManager initialKeys={keys} />
-      <LLMProvidersManager />
+
+      <Tabs defaultValue="api-keys">
+        <TabsList>
+          <TabsTrigger value="api-keys">API Keys</TabsTrigger>
+          <TabsTrigger value="llm-providers">LLM Providers</TabsTrigger>
+          <TabsTrigger value="api-reference">API Reference</TabsTrigger>
+        </TabsList>
+
+        <TabsContent value="api-keys" className="mt-6">
+          <ApiKeysManager initialKeys={keys} />
+        </TabsContent>
+
+        <TabsContent value="llm-providers" className="mt-6">
+          <LLMProvidersManager />
+        </TabsContent>
+
+        <TabsContent value="api-reference" className="mt-6">
+          <ApiReferenceSection />
+        </TabsContent>
+      </Tabs>
     </div>
   )
 }

--- a/app/api/developer/llm-keys/route.ts
+++ b/app/api/developer/llm-keys/route.ts
@@ -19,11 +19,30 @@ export async function GET() {
   if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
 
   const serviceClient = createServiceClient()
-  const { data: rows } = await serviceClient
-    .from('llm_provider_keys')
-    .select('provider, key_preview, is_valid, last_verified_at')
-    .eq('user_id', user.id)
-    .order('updated_at', { ascending: false })
+
+  // Fetch keys and this-month usage counts in parallel
+  const startOfMonth = new Date()
+  startOfMonth.setUTCDate(1)
+  startOfMonth.setUTCHours(0, 0, 0, 0)
+
+  const [{ data: rows }, { data: usageRows }] = await Promise.all([
+    serviceClient
+      .from('llm_provider_keys')
+      .select('provider, key_preview, is_valid, last_verified_at')
+      .eq('user_id', user.id)
+      .order('updated_at', { ascending: false }),
+    serviceClient
+      .from('ai_chats')
+      .select('llm_provider')
+      .eq('user_id', user.id)
+      .gte('created_at', startOfMonth.toISOString()),
+  ])
+
+  // Count chats per provider for this month
+  const usageCounts = new Map<string, number>()
+  for (const row of (usageRows ?? [])) {
+    usageCounts.set(row.llm_provider, (usageCounts.get(row.llm_provider) ?? 0) + 1)
+  }
 
   // One record per provider (take most recent if multiple)
   const seen = new Set<string>()
@@ -36,6 +55,7 @@ export async function GET() {
         key_preview: row.key_preview,
         is_valid: row.is_valid,
         last_verified_at: row.last_verified_at,
+        requests_this_month: usageCounts.get(row.provider) ?? 0,
       })
     }
   }
@@ -49,7 +69,7 @@ export async function GET() {
   for (const { provider, envValue } of envProviders) {
     if (envValue && !seen.has(provider)) {
       seen.add(provider)
-      records.push({ provider, key_preview: null, is_valid: null, last_verified_at: null })
+      records.push({ provider, key_preview: null, is_valid: null, last_verified_at: null, requests_this_month: usageCounts.get(provider) ?? 0 })
     }
   }
 

--- a/app/api/developer/llm-keys/route.ts
+++ b/app/api/developer/llm-keys/route.ts
@@ -20,29 +20,41 @@ export async function GET() {
 
   const serviceClient = createServiceClient()
 
-  // Fetch keys and this-month usage counts in parallel
   const startOfMonth = new Date()
   startOfMonth.setUTCDate(1)
   startOfMonth.setUTCHours(0, 0, 0, 0)
+  const since = startOfMonth.toISOString()
 
-  const [{ data: rows }, { data: usageRows }] = await Promise.all([
+  const providers: LLMProvider[] = ['claude', 'gemini', 'openai']
+
+  // Fetch keys + per-provider chat counts for this month in parallel
+  const [
+    { data: rows, error: keysError },
+    ...countResults
+  ] = await Promise.all([
     serviceClient
       .from('llm_provider_keys')
       .select('provider, key_preview, is_valid, last_verified_at')
       .eq('user_id', user.id)
       .order('updated_at', { ascending: false }),
-    serviceClient
-      .from('ai_chats')
-      .select('llm_provider')
-      .eq('user_id', user.id)
-      .gte('created_at', startOfMonth.toISOString()),
+    ...providers.map((p) =>
+      serviceClient
+        .from('ai_chats')
+        .select('*', { count: 'exact', head: true })
+        .eq('user_id', user.id)
+        .eq('llm_provider', p)
+        .gte('created_at', since)
+    ),
   ])
 
-  // Count chats per provider for this month
-  const usageCounts = new Map<string, number>()
-  for (const row of (usageRows ?? [])) {
-    usageCounts.set(row.llm_provider, (usageCounts.get(row.llm_provider) ?? 0) + 1)
+  if (keysError) {
+    console.error('[GET /api/developer/llm-keys] keys query error:', keysError.message)
+    return NextResponse.json({ error: 'Failed to load provider keys' }, { status: 500 })
   }
+
+  const chatCounts = new Map<LLMProvider, number>(
+    providers.map((p, i) => [p, countResults[i].count ?? 0])
+  )
 
   // One record per provider (take most recent if multiple)
   const seen = new Set<string>()
@@ -55,7 +67,7 @@ export async function GET() {
         key_preview: row.key_preview,
         is_valid: row.is_valid,
         last_verified_at: row.last_verified_at,
-        requests_this_month: usageCounts.get(row.provider) ?? 0,
+        chats_this_month: chatCounts.get(row.provider as LLMProvider) ?? 0,
       })
     }
   }
@@ -69,7 +81,7 @@ export async function GET() {
   for (const { provider, envValue } of envProviders) {
     if (envValue && !seen.has(provider)) {
       seen.add(provider)
-      records.push({ provider, key_preview: null, is_valid: null, last_verified_at: null, requests_this_month: usageCounts.get(provider) ?? 0 })
+      records.push({ provider, key_preview: null, is_valid: null, last_verified_at: null, chats_this_month: chatCounts.get(provider) ?? 0 })
     }
   }
 

--- a/components/ai-assistant/LLMProvidersManager.tsx
+++ b/components/ai-assistant/LLMProvidersManager.tsx
@@ -74,7 +74,7 @@ export function LLMProvidersManager() {
       setKeys((prev) => {
         const existing = prev.find((k) => k.provider === provider)
         const next = prev.filter((k) => k.provider !== provider)
-        return [...next, { provider, key_preview: data.key_preview, is_valid: data.is_valid, last_verified_at: new Date().toISOString(), requests_this_month: existing?.requests_this_month ?? 0 }]
+        return [...next, { provider, key_preview: data.key_preview, is_valid: data.is_valid, last_verified_at: new Date().toISOString(), chats_this_month: existing?.chats_this_month ?? 0 }]
       })
       toast.success(data.is_valid ? 'Key saved and verified' : 'Key saved (verification failed — check the key)')
       setEditing(null)
@@ -181,7 +181,7 @@ export function LLMProvidersManager() {
                       )}
                       {keyRecord.is_valid && (
                         <span className="text-xs text-muted-foreground">
-                          <span className="font-medium text-gray-700">{keyRecord.requests_this_month}</span> request{keyRecord.requests_this_month !== 1 ? 's' : ''} this month
+                          <span className="font-medium text-gray-700">{keyRecord.chats_this_month}</span> chat{keyRecord.chats_this_month !== 1 ? 's' : ''} this month
                         </span>
                       )}
                     </>

--- a/components/ai-assistant/LLMProvidersManager.tsx
+++ b/components/ai-assistant/LLMProvidersManager.tsx
@@ -72,8 +72,9 @@ export function LLMProvidersManager() {
       const data = await res.json()
       if (!res.ok) { toast.error(data.error ?? 'Failed to save key'); return }
       setKeys((prev) => {
+        const existing = prev.find((k) => k.provider === provider)
         const next = prev.filter((k) => k.provider !== provider)
-        return [...next, { provider, key_preview: data.key_preview, is_valid: data.is_valid, last_verified_at: new Date().toISOString() }]
+        return [...next, { provider, key_preview: data.key_preview, is_valid: data.is_valid, last_verified_at: new Date().toISOString(), requests_this_month: existing?.requests_this_month ?? 0 }]
       })
       toast.success(data.is_valid ? 'Key saved and verified' : 'Key saved (verification failed — check the key)')
       setEditing(null)
@@ -128,51 +129,65 @@ export function LLMProvidersManager() {
             const isDeleting = deleting === provider
 
             return (
-              <div key={provider} className="rounded-lg border border-gray-100 p-4 space-y-3">
-                <div className="flex items-start justify-between gap-3">
-                  <div>
-                    <p className={`text-sm font-medium ${color}`}>{label}</p>
-                    <p className="text-xs text-muted-foreground">Models: {models}</p>
-                    {note && <p className="text-xs text-muted-foreground italic mt-0.5">{note}</p>}
-                  </div>
-                  <div className="flex items-center gap-1.5 shrink-0">
+              <div key={provider} className="rounded-lg border border-gray-100 p-4 space-y-2">
+                {/* Row 1: name + action buttons */}
+                <div className="flex items-center justify-between gap-2">
+                  <p className={`text-sm font-medium ${color}`}>{label}</p>
+                  <div className="flex items-center gap-1 shrink-0">
                     {keyRecord ? (
                       <>
-                        <span className="flex items-center gap-1 text-xs font-mono text-muted-foreground">
-                          {keyRecord.key_preview}
-                        </span>
-                        <Badge
-                          variant={keyRecord.is_valid ? 'default' : keyRecord.is_valid === false ? 'destructive' : 'secondary'}
-                          className="text-[10px]"
-                        >
-                          {keyRecord.is_valid ? (
-                            <><Check className="h-2.5 w-2.5 mr-1" />Connected</>
-                          ) : keyRecord.is_valid === false ? (
-                            <><X className="h-2.5 w-2.5 mr-1" />Invalid</>
-                          ) : (
-                            'Untested'
-                          )}
-                        </Badge>
                         <Button
                           variant="ghost" size="sm"
-                          className="h-6 px-1.5 text-xs"
+                          className="h-7 w-7 p-0"
                           onClick={() => { setEditing(provider); setInputValues((prev) => ({ ...prev, [provider]: '' })) }}
                         >
-                          <Pencil className="h-3 w-3" />
+                          <Pencil className="h-3.5 w-3.5" />
                         </Button>
                         <Button
                           variant="ghost" size="sm"
-                          className="h-6 px-1.5 text-xs text-red-500 hover:text-red-600 hover:bg-red-50"
+                          className="h-7 w-7 p-0 text-red-500 hover:text-red-600 hover:bg-red-50"
                           onClick={() => handleDelete(provider)}
                           disabled={isDeleting}
                         >
-                          {isDeleting ? <Loader2 className="h-3 w-3 animate-spin" /> : <Trash2 className="h-3 w-3" />}
+                          {isDeleting ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Trash2 className="h-3.5 w-3.5" />}
                         </Button>
                       </>
-                    ) : (
-                      <Badge variant="secondary" className="text-[10px]">Not configured</Badge>
-                    )}
+                    ) : null}
                   </div>
+                </div>
+
+                {/* Row 2: models + note */}
+                <p className="text-xs text-muted-foreground">Models: {models}</p>
+                {note && <p className="text-xs text-muted-foreground italic">{note}</p>}
+
+                {/* Row 3: status badge + key preview + usage */}
+                <div className="flex flex-wrap items-center gap-2 pt-0.5">
+                  {keyRecord ? (
+                    <>
+                      <Badge
+                        variant={keyRecord.is_valid ? 'default' : keyRecord.is_valid === false ? 'destructive' : 'secondary'}
+                        className="text-[10px]"
+                      >
+                        {keyRecord.is_valid ? (
+                          <><Check className="h-2.5 w-2.5 mr-1" />Connected</>
+                        ) : keyRecord.is_valid === false ? (
+                          <><X className="h-2.5 w-2.5 mr-1" />Invalid</>
+                        ) : (
+                          'Untested'
+                        )}
+                      </Badge>
+                      {keyRecord.key_preview && (
+                        <span className="text-xs font-mono text-muted-foreground">{keyRecord.key_preview}</span>
+                      )}
+                      {keyRecord.is_valid && (
+                        <span className="text-xs text-muted-foreground">
+                          <span className="font-medium text-gray-700">{keyRecord.requests_this_month}</span> request{keyRecord.requests_this_month !== 1 ? 's' : ''} this month
+                        </span>
+                      )}
+                    </>
+                  ) : (
+                    <Badge variant="secondary" className="text-[10px]">Not configured</Badge>
+                  )}
                 </div>
 
                 {(isEditing || !keyRecord) && (

--- a/components/dashboard/Sidebar.tsx
+++ b/components/dashboard/Sidebar.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect, useTransition } from 'react'
 import Link from 'next/link'
-import { usePathname, useRouter } from 'next/navigation'
+import { usePathname } from 'next/navigation'
 import {
   LayoutDashboard, FileText, PlusCircle, Users, FolderOpen, Tag, LogOut, PenLine, Menu, X, MessageSquare, Loader2, Code, Bot,
 } from 'lucide-react'
@@ -18,7 +18,6 @@ interface SidebarProps {
 
 export function Sidebar({ profile }: SidebarProps) {
   const pathname = usePathname()
-  const router = useRouter()
   const supabase = createClient()
   const role = profile.role as Role
   const [mobileOpen, setMobileOpen] = useState(false)
@@ -32,8 +31,7 @@ export function Sidebar({ profile }: SidebarProps) {
   function handleLogout() {
     startTransition(async () => {
       await supabase.auth.signOut()
-      router.push('/login')
-      router.refresh()
+      window.location.href = '/login'
     })
   }
 

--- a/components/dashboard/Sidebar.tsx
+++ b/components/dashboard/Sidebar.tsx
@@ -30,8 +30,11 @@ export function Sidebar({ profile }: SidebarProps) {
 
   function handleLogout() {
     startTransition(async () => {
-      await supabase.auth.signOut()
-      window.location.href = '/login'
+      try {
+        await supabase.auth.signOut()
+      } finally {
+        globalThis.location.href = '/login'
+      }
     })
   }
 

--- a/components/ui/tabs.tsx
+++ b/components/ui/tabs.tsx
@@ -1,0 +1,62 @@
+"use client"
+
+import { Tabs as TabsPrimitive } from "@base-ui/react/tabs"
+import { cn } from "@/lib/utils"
+
+function Tabs({
+  className,
+  ...props
+}: TabsPrimitive.Root.Props) {
+  return (
+    <TabsPrimitive.Root
+      data-slot="tabs"
+      className={cn("flex flex-col gap-2", className)}
+      {...props}
+    />
+  )
+}
+
+function TabsList({
+  className,
+  ...props
+}: TabsPrimitive.List.Props) {
+  return (
+    <TabsPrimitive.List
+      data-slot="tabs-list"
+      className={cn(
+        "inline-flex items-center justify-start gap-1 rounded-lg bg-muted p-1 text-muted-foreground",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function TabsTrigger({ className, ...props }: TabsPrimitive.Tab.Props) {
+  return (
+    <TabsPrimitive.Tab
+      data-slot="tabs-trigger"
+      className={cn(
+        "inline-flex items-center justify-center whitespace-nowrap rounded-md px-3 py-1.5 text-sm font-medium transition-all",
+        "hover:text-foreground",
+        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+        "disabled:pointer-events-none disabled:opacity-50",
+        "data-[active]:bg-background data-[active]:text-foreground data-[active]:shadow-sm",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function TabsContent({ className, ...props }: TabsPrimitive.Panel.Props) {
+  return (
+    <TabsPrimitive.Panel
+      data-slot="tabs-content"
+      className={cn("outline-none", className)}
+      {...props}
+    />
+  )
+}
+
+export { Tabs, TabsList, TabsTrigger, TabsContent }

--- a/features/ai-assistant/types.ts
+++ b/features/ai-assistant/types.ts
@@ -116,6 +116,7 @@ export type LLMProviderKeyRecord = {
   key_preview: string | null
   is_valid: boolean | null
   last_verified_at: string | null
+  requests_this_month: number
 }
 
 export type ProviderStatus = {

--- a/features/ai-assistant/types.ts
+++ b/features/ai-assistant/types.ts
@@ -116,7 +116,7 @@ export type LLMProviderKeyRecord = {
   key_preview: string | null
   is_valid: boolean | null
   last_verified_at: string | null
-  requests_this_month: number
+  chats_this_month: number
 }
 
 export type ProviderStatus = {

--- a/middleware.ts
+++ b/middleware.ts
@@ -40,8 +40,8 @@ export async function middleware(request: NextRequest) {
       return NextResponse.redirect(url)
     }
 
-    // Protect /dashboard/admin and /dashboard/developer routes — require admin role
-    if (pathname.startsWith('/dashboard/admin') || pathname.startsWith('/dashboard/developer')) {
+    // Protect /dashboard/admin routes — require admin role
+    if (pathname.startsWith('/dashboard/admin')) {
       const { data: profileData } = await supabase
         .from('profiles')
         .select('role')


### PR DESCRIPTION
- Add tabbed layout (API Keys / LLM Providers / API Reference) to developer page
- Add shadcn/ui Tabs component (base-ui backed, Tailwind v3 compatible)
- Show monthly request usage per connected LLM provider
- Allow authors to access /dashboard/developer (was admin-only in middleware)
- Fix sign out using window.location.href to avoid stale session cache
- Fix LLM provider card layout for mobile (stacked rows, flex-wrap)